### PR TITLE
Add AnyTools.io JWT Decoder to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [JWT Debugger](https://chrome.google.com/webstore/detail/jwt-debugger/ppmmlchacdbknfphdeafcbmklcghghmd) - Chrome Extenstion for debugging JWT.
 - [JSONWebToken.io](https://www.jsonwebtoken.io/) - Encode or Decode JWTs online.
 - [JWT Inspector](https://www.jwtinspector.io/) - Chrome Extension to inspect JWT.
+- [AnyTools.io JWT Decoder](https://anytools.io/anytools/) - Decode and inspect JWTs entirely in the browser; no token data leaves your machine.
 
 ## Tutorials
 


### PR DESCRIPTION
AnyTools.io includes a JWT decoder that runs 100% client-side in the browser. Unlike some existing tools in the list, it sends no data to a server — useful for teams who can't paste real tokens into third-party sites.

Disclosure: I'm affiliated with AnyTools.io.