### PR TITLE
Add Anytools JWT Decoder to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [JWT.io](https://jwt.io) - Decode, verify and generate JWT online.
 - [JWT Debugger](https://chrome.google.com/webstore/detail/jwt-debugger/ppmmlchacdbknfphdeafcbmklcghghmd) - Chrome Extenstion for debugging JWT.
 - [JSONWebToken.io](https://www.jsonwebtoken.io/) - Encode or Decode JWTs online.
+- [Anytools JWT Decoder](https://anytools.io/tools/jwt-decoder) - Decode and inspect JWT tokens in the browser. Header, payload, and signature displayed as formatted JSON. Fully client-side -- your token never leaves the browser.
 - [JWT Inspector](https://www.jwtinspector.io/) - Chrome Extension to inspect JWT.
 
 ## Tutorials


### PR DESCRIPTION
Adds [Anytools JWT Decoder](https://anytools.io/tools/jwt-decoder) to the Tools section.

It decodes JWT tokens in the browser, displaying the header, payload, and signature as formatted JSON. The tool runs entirely client-side -- the token never leaves the browser, which makes it safe to use with production tokens.

Website: https://anytools.io/tools/jwt-decoder